### PR TITLE
Fixed spelling of echo

### DIFF
--- a/Hello.php
+++ b/Hello.php
@@ -1,2 +1,2 @@
 $hello = "Hello World"
-echoo #hello;
+echo #hello;


### PR DESCRIPTION
The spelling of echo had an extra o which was deleted